### PR TITLE
Add the Users/alias endpoint

### DIFF
--- a/lib/braze_api/client.rb
+++ b/lib/braze_api/client.rb
@@ -3,12 +3,14 @@ require 'JSON'
 require 'braze_api/response/raise_error'
 require 'braze_api/errors'
 require 'braze_api/endpoints/users/track'
+require 'braze_api/endpoints/users/alias'
 
 module BrazeAPI
   # The top-level class that handles configuration and connection to the Braze API.
   class Client
     attr_reader :app_id
     include BrazeAPI::Endpoints::Users::Track
+    include BrazeAPI::Endpoints::Users::Alias
 
     def initialize(api_key:, braze_url:, app_id:)
       @api_key = api_key

--- a/lib/braze_api/endpoints/users/alias.rb
+++ b/lib/braze_api/endpoints/users/alias.rb
@@ -1,0 +1,21 @@
+module BrazeAPI
+  module Endpoints
+    module Users
+      # Methods to call the users/alias/new endpoint from a client instance
+      module Alias
+        PATH = '/users/alias/new'.freeze
+
+        # The main method calling the endpoint.
+        # Called with an alias name and an alias label.
+        def alias(alias_name:, alias_label:)
+          post(
+            PATH,
+            params: {
+              user_aliases: [{ alias_name: alias_name, alias_label: alias_label }]
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/braze_api/endpoints/users/alias_spec.rb
+++ b/spec/braze_api/endpoints/users/alias_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe BrazeAPI::Endpoints::Users::Alias do
+  let(:api_key) { 'abcdefg' }
+  let(:app_id) { 'hijklmnop' }
+  let(:braze_url) { 'https://rest.fra-01.braze.eu' }
+  let(:alias_name) { 'hello@appearhere.co.uk' }
+  let(:alias_label) { 'email' }
+  let(:subject) { BrazeAPI::Client.new(api_key: api_key, app_id: app_id, braze_url: braze_url) }
+  before { allow(subject).to receive(:post).and_return('success') }
+
+  describe '.alias' do
+    it 'creates a user alias' do
+      expect(subject)
+        .to receive(:post)
+        .with(
+          '/users/alias/new',
+          params: { user_aliases: [{ alias_name: alias_name, alias_label: alias_label }] }
+        )
+
+      subject.alias(alias_name: alias_name, alias_label: alias_label)
+    end
+  end
+end


### PR DESCRIPTION
Add the[ users/alias/new endpoint](https://www.braze.com/docs/api/endpoints/user_data/post_user_alias/) and the `alias` method which takes a alias_name and alias_label as arguments to create an alias in Braze.