### PR TITLE
Add the users/identify endpoint

### DIFF
--- a/lib/braze_api/client.rb
+++ b/lib/braze_api/client.rb
@@ -4,6 +4,7 @@ require 'braze_api/response/raise_error'
 require 'braze_api/errors'
 require 'braze_api/endpoints/users/track'
 require 'braze_api/endpoints/users/alias'
+require 'braze_api/endpoints/users/identify'
 
 module BrazeAPI
   # The top-level class that handles configuration and connection to the Braze API.
@@ -11,6 +12,7 @@ module BrazeAPI
     attr_reader :app_id
     include BrazeAPI::Endpoints::Users::Track
     include BrazeAPI::Endpoints::Users::Alias
+    include BrazeAPI::Endpoints::Users::Identify
 
     def initialize(api_key:, braze_url:, app_id:)
       @api_key = api_key

--- a/lib/braze_api/endpoints/users/identify.rb
+++ b/lib/braze_api/endpoints/users/identify.rb
@@ -1,0 +1,24 @@
+module BrazeAPI
+  module Endpoints
+    module Users
+      # Methods to call the users/identify endpoint from a client instance
+      module Identify
+        PATH = '/users/identify'.freeze
+        # The main method calling the endpoint.
+        # Called with an object containing the user alias object
+        # and the external id of the user being identified.
+        def identify(user_alias:, external_id:)
+          post(
+            PATH,
+            params: { aliases_to_identify: [
+              {
+                external_id: external_id,
+                user_alias: user_alias
+              }
+            ] }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/braze_api/endpoints/users/identify_spec.rb
+++ b/spec/braze_api/endpoints/users/identify_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe BrazeAPI::Endpoints::Users::Identify do
+  let(:api_key) { 'abcdefg' }
+  let(:app_id) { 'hijklmnop' }
+  let(:braze_url) { 'https://rest.fra-01.braze.eu' }
+  let(:user_alias) { { alias_name: 'hello@appearhere.co.uk', alias_label: 'email' } }
+  let(:external_id) { '12314es5' }
+  let(:subject) { BrazeAPI::Client.new(api_key: api_key, app_id: app_id, braze_url: braze_url) }
+  before { allow(subject).to receive(:post).and_return('success') }
+
+  describe '.identify' do
+    it 'creates a user alias' do
+      expect(subject)
+        .to receive(:post)
+        .with(
+          '/users/identify',
+          params: { aliases_to_identify: [{ external_id: external_id, user_alias: user_alias }] }
+        )
+
+      subject.identify(user_alias: user_alias, external_id: external_id)
+    end
+  end
+end


### PR DESCRIPTION
Adds the [users/identify endpoint](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/)

When passed a user alias object and an external id, the .identify method will call the users/identify endpoint to link the two users.