### PR TITLE
Add users/export endpoint

### DIFF
--- a/lib/braze_api/client.rb
+++ b/lib/braze_api/client.rb
@@ -5,6 +5,7 @@ require 'braze_api/errors'
 require 'braze_api/endpoints/users/track'
 require 'braze_api/endpoints/users/alias'
 require 'braze_api/endpoints/users/identify'
+require 'braze_api/endpoints/users/export'
 
 module BrazeAPI
   # The top-level class that handles configuration and connection to the Braze API.
@@ -13,6 +14,7 @@ module BrazeAPI
     include BrazeAPI::Endpoints::Users::Track
     include BrazeAPI::Endpoints::Users::Alias
     include BrazeAPI::Endpoints::Users::Identify
+    include BrazeAPI::Endpoints::Users::Export
 
     def initialize(api_key:, braze_url:, app_id:)
       @api_key = api_key

--- a/lib/braze_api/endpoints/users/export.rb
+++ b/lib/braze_api/endpoints/users/export.rb
@@ -1,0 +1,25 @@
+module BrazeAPI
+  module Endpoints
+    module Users
+      # Methods to call the users/export endpoint from a client instance
+      module Export
+        PATH = '/users/export/ids'.freeze
+        # The main method calling the endpoint.
+        # Called with an email, array of external_ids,
+        # and the fields that you wish to export data on.
+        # can only search by one email at a time, but can search with multiple ids
+        def export_users(email: nil, external_ids: [], fields_to_export: [])
+          body = {}.tap do |b|
+            b[:external_ids] = external_ids unless external_ids.empty?
+            b[:email_address] = email if email && external_ids.empty?
+            b[:fields_to_export] = fields_to_export unless fields_to_export.empty?
+          end
+          post(
+            PATH,
+            params: body
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/braze_api/endpoints/users/export_spec.rb
+++ b/spec/braze_api/endpoints/users/export_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe BrazeAPI::Endpoints::Users::Export do
+  let(:api_key) { 'abcdefg' }
+  let(:app_id) { 'hijklmnop' }
+  let(:braze_url) { 'https://rest.fra-01.braze.eu' }
+  let(:external_ids) { %w(12314es5 23r2352f 124234f) }
+  let(:email) { 'hello@appearhere.co.uk' }
+  let(:fields_to_export) { %w(custom_attributes custom_events) }
+  let(:subject) { BrazeAPI::Client.new(api_key: api_key, app_id: app_id, braze_url: braze_url) }
+  before { allow(subject).to receive(:post).and_return('success') }
+
+  describe '.export_users' do
+    context 'when external ids are provided' do
+      it 'exports a list of users' do
+        expect(subject)
+          .to receive(:post)
+          .with(
+            '/users/export/ids',
+            params: { external_ids: external_ids }
+          )
+
+        subject.export_users(external_ids: external_ids)
+      end
+
+      it 'sends the fields to export' do
+        expect(subject)
+          .to receive(:post)
+          .with(
+            '/users/export/ids',
+            params: { external_ids: external_ids, fields_to_export: fields_to_export }
+          )
+
+        subject.export_users(external_ids: external_ids, fields_to_export: fields_to_export)
+      end
+    end
+
+    context 'when an email is provided' do
+      it 'exports a list of users by email' do
+        expect(subject)
+          .to receive(:post)
+          .with(
+            '/users/export/ids',
+            params: { email_address: email }
+          )
+
+        subject.export_users(email: email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the [users/export endpoint](https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/) to allow the exporting of users by ids or email.