### PR TITLE
Add subscription/status/set endpoint

### DIFF
--- a/lib/braze_api/client.rb
+++ b/lib/braze_api/client.rb
@@ -6,6 +6,7 @@ require 'braze_api/endpoints/users/track'
 require 'braze_api/endpoints/users/alias'
 require 'braze_api/endpoints/users/identify'
 require 'braze_api/endpoints/users/export'
+require 'braze_api/endpoints/subscription_groups/status'
 
 module BrazeAPI
   # The top-level class that handles configuration and connection to the Braze API.
@@ -15,6 +16,7 @@ module BrazeAPI
     include BrazeAPI::Endpoints::Users::Alias
     include BrazeAPI::Endpoints::Users::Identify
     include BrazeAPI::Endpoints::Users::Export
+    include BrazeAPI::Endpoints::SubscriptionGroups::Status
 
     def initialize(api_key:, braze_url:, app_id:)
       @api_key = api_key

--- a/lib/braze_api/endpoints/subscription_groups/status.rb
+++ b/lib/braze_api/endpoints/subscription_groups/status.rb
@@ -1,0 +1,17 @@
+module BrazeAPI
+  module Endpoints
+    module SubscriptionGroups
+      # Methods to call the subscription/status endpoint from a client instance
+      module Status
+        PATH = '/subscription/status/set'.freeze
+        # The method to update a users subscription status
+        # Args object will look like: {subscription_state: 'subscribed', subscription_group_id: id, external_id: uuid}
+        # with either an external_id or an email and the subscription state and subscription group id
+        def update_status(args = {})
+          args.compact!
+          post(PATH, params: args)
+        end
+      end
+    end
+  end
+end

--- a/spec/braze_api/endpoints/subscription_groups/status_spec.rb
+++ b/spec/braze_api/endpoints/subscription_groups/status_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe BrazeAPI::Endpoints::SubscriptionGroups::Status do
+  let(:api_key) { 'abcdefg' }
+  let(:app_id) { 'hijklmnop' }
+  let(:braze_url) { 'https://rest.fra-01.braze.eu' }
+  let(:email) { 'hello@appearhere.co.uk' }
+  let(:external_id) { '12314es5' }
+  let(:subscription_group_id) { '12' }
+  let(:subject) { BrazeAPI::Client.new(api_key: api_key, app_id: app_id, braze_url: braze_url) }
+  before { allow(subject).to receive(:post).and_return('success') }
+
+  describe '.update_status' do
+    it 'updates the subscription status with an external id' do
+      expect(subject)
+        .to receive(:post)
+        .with(
+          '/subscription/status/set',
+          params: { external_id: external_id, subscription_group_id: subscription_group_id, subscription_state: 'subscribed' }
+        )
+
+      subject.update_status(external_id: external_id, subscription_group_id: subscription_group_id, subscription_state: 'subscribed')
+    end
+  end
+end


### PR DESCRIPTION
Add the [/subscription/status/set endpoint](https://www.braze.com/docs/api/endpoints/subscription_groups/post_update_user_subscription_group_status/)

Allow the updating of a users subscription group status.