### PR TITLE
Specify gem versions and bump rake version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,21 +2,21 @@ PATH
   remote: .
   specs:
     braze_api (0.1.0)
-      faraday
+      faraday (~> 1.0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
+    coderay (1.1.3)
     diff-lcs (1.4.4)
-    faraday (0.15.4)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    method_source (0.9.2)
+    method_source (1.0.0)
     multipart-post (2.1.1)
-    pry (0.11.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rake (10.5.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (12.3.3)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -37,9 +37,9 @@ PLATFORMS
 DEPENDENCIES
   braze_api!
   bundler (~> 2.0)
-  pry
-  rake (~> 10.0)
-  rspec (~> 3.0)
+  pry (~> 0.13.1)
+  rake (~> 12.3.3)
+  rspec (~> 3.9)
 
 BUNDLED WITH
    2.0.1

--- a/braze_api.gemspec
+++ b/braze_api.gemspec
@@ -36,9 +36,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '~> 1.0.1'
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "rake", "~> 12.3.3"
+  spec.add_development_dependency "rspec", "~> 3.9"
+  spec.add_development_dependency "pry", '~> 0.13.1'
 end


### PR DESCRIPTION
Specify versions for faraday and pry.  Bump rake version to fix security vulnerability.