### PR TITLE
Change faraday version to 0.15

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     braze_api (0.1.0)
-      faraday (~> 1.0)
+      faraday (~> 0.15)
 
 GEM
   remote: https://rubygems.org/
@@ -10,7 +10,7 @@ GEM
     ast (2.4.1)
     coderay (1.1.3)
     diff-lcs (1.4.4)
-    faraday (1.0.1)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     method_source (1.0.0)
     multipart-post (2.1.1)

--- a/braze_api.gemspec
+++ b/braze_api.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4.4'
 
-  spec.add_runtime_dependency 'faraday', '~> 1.0'
+  spec.add_runtime_dependency 'faraday', '~> 0.15'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pry', '~> 0.13.1'
   spec.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
The faraday version was too advanced at 1.0, bumps it back to 0.15 so it is more compatible with other dependencies.