### PR TITLE
Delete users endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-# v0.1.1
+# v0.1.2
 
-Update faraday dependency to v0.15
+Adds method to delete users.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ Called with an email and not passed fields to export will return all fields for 
 ```ruby
 braze.export_users(email: 'hello@gmail.com')
 ```
+### Users Delete Endpoint:
+
+[Delete Users](https://www.braze.com/docs/api/endpoints/user_data/post_user_delete)
+
+Called with an array of external ids returns an object with the number of users queued for deletion
+```ruby
+braze.delete_users(external_ids: ['123', '345'])
+```
+
+Called with an array of braze ids returns an object with the number of users queued for deletion
+```ruby
+braze.delete_users(braze_ids: ['123', '345'])
+```
+
+Called with an array of user aliases returns an object with the number of users queued for deletion
+```ruby
+braze.delete_users(user_aliases: [ { user_alias: { alias_name: 'pete', alias_label: 'sampras' } } ])
+```
 
 ### Subscription Groups Status Set Endpoint:
 

--- a/lib/braze_api/client.rb
+++ b/lib/braze_api/client.rb
@@ -8,6 +8,7 @@ require 'braze_api/endpoints/users/track'
 require 'braze_api/endpoints/users/alias'
 require 'braze_api/endpoints/users/identify'
 require 'braze_api/endpoints/users/export'
+require 'braze_api/endpoints/users/delete'
 require 'braze_api/endpoints/subscription_groups/status'
 
 module BrazeAPI
@@ -18,6 +19,7 @@ module BrazeAPI
     include BrazeAPI::Endpoints::Users::Alias
     include BrazeAPI::Endpoints::Users::Identify
     include BrazeAPI::Endpoints::Users::Export
+    include BrazeAPI::Endpoints::Users::Delete
     include BrazeAPI::Endpoints::SubscriptionGroups::Status
 
     def initialize(api_key:, braze_url:, app_id:)

--- a/lib/braze_api/endpoints/users/delete.rb
+++ b/lib/braze_api/endpoints/users/delete.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BrazeAPI
+  module Endpoints
+    module Users
+      # Methods to call the users/delete endpoint from a client instance
+      module Delete
+        PATH = '/users/delete'
+
+        # The main method calling the endpoint.
+        # Called with an object containing optional keys of
+        # external_ids, user_aliases, braze_ids
+        # external_ids => optional array of strings
+        # braze_ids => optional array of strings
+        # user_aliases => optional array of UserAlias objects
+        def delete_users(external_ids: [], user_aliases: [], braze_ids: [])
+          args = {}
+          args[:external_ids] = external_ids unless external_ids.empty?
+          args[:braze_ids] = braze_ids unless braze_ids.empty?
+          args[:user_aliases] = user_aliases unless user_aliases.empty?
+          post(PATH, params: args)
+        end
+      end
+    end
+  end
+end

--- a/lib/braze_api/version.rb
+++ b/lib/braze_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrazeAPI
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/braze_api/endpoints/users/delete_spec.rb
+++ b/spec/braze_api/endpoints/users/delete_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe BrazeAPI::Endpoints::Users::Delete do
+  let(:api_key) { 'abcdefg' }
+  let(:app_id) { 'hijklmnop' }
+  let(:braze_url) { 'https://rest.fra-01.braze.eu' }
+  let(:external_ids) { %w[12314es5 23r2352f 124234f] }
+  let(:braze_ids) { %w[a123 b456 c789] }
+  let(:user_aliases) { [{user_alias: {alias_name: 'pete', alias_label: 'sampras'}}] }
+  let(:subject) { BrazeAPI::Client.new(api_key: api_key, app_id: app_id, braze_url: braze_url) }
+  before { allow(subject).to receive(:post).and_return('success') }
+
+  describe '.delete_users' do
+    context 'when external ids are provided' do
+      it 'posts to `/users/delete`' do
+        expect(subject)
+          .to receive(:post)
+          .with(
+            '/users/delete',
+            params: { external_ids: external_ids }
+          )
+
+        subject.delete_users(external_ids: external_ids)
+      end
+    end
+
+    context 'when braze ids are provided' do
+      it 'posts to `/users/delete`' do
+        expect(subject)
+          .to receive(:post)
+          .with(
+            '/users/delete',
+            params: { braze_ids: braze_ids }
+          )
+
+        subject.delete_users(braze_ids: braze_ids)
+      end
+    end
+
+    context 'when user aliases are provided' do
+      it 'posts to `/users/delete`' do
+        expect(subject)
+          .to receive(:post)
+          .with(
+            '/users/delete',
+            params: { user_aliases: user_aliases }
+          )
+
+        subject.delete_users(user_aliases: user_aliases)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is to fill a need to delete users via the api, which is not presently possible in this gem, nor in the UI.