### PR TITLE
Adds extra support for subscription groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,48 @@ braze.update_status(
 )
 ```
 
+### Subscription Group Status Endpoint:
+
+[Get Subscription Group Status](https://www.braze.com/docs/api/endpoints/subscription_groups/get_list_user_subscription_group_status/)
+
+With this method you can get a user's subscription group state. One of external_id or email or phone is required for each user.
+The external_id, email, phone can be passed as an array of strings with a max of 50. Submitting both an email address and phone number (with no external_id) will result in an error.
+
+```ruby
+# With an external_id (can also be an array)
+braze.status(
+  external_id: '123',
+  subscription_group_id: 'b6dw887f-d8de-456f-345a-fc5ad8734723'
+)
+# With an email (can also be an array)
+braze.status(
+  email: 'hello@gmail.com',
+  subscription_group_id: 'b6dw887f-d8de-456f-345a-fc5ad8734723'
+)
+# With an phone (can also be an array)
+braze.status(
+  phone: 'hello@gmail.com',
+  subscription_group_id: 'b6dw887f-d8de-456f-345a-fc5ad8734723'
+)
+```
+
+### Subscription Groups Statuses Endpoint:
+
+[Get Subscription Groups Statuses for a User](https://www.braze.com/docs/api/endpoints/subscription_groups/get_list_user_subscription_groups/)
+
+With this method you can get a user's subscription group states.  It is called with an email and an external id for an email subscription group, and with a phone number and an external id for a push subscription group.
+```ruby
+# With only an email for email subscription groups (email can also be an array)
+braze.statuses(
+  external_id: '123',
+  email: 'hello@gmail.com',
+)
+# With only an phone for sms subscription groups (phone can also be an array)
+braze.statuses(
+  external_id: '123',
+  phone: '+440000000000',
+)
+```
 
 ## Development
 

--- a/lib/braze_api/client.rb
+++ b/lib/braze_api/client.rb
@@ -10,6 +10,8 @@ require 'braze_api/endpoints/users/identify'
 require 'braze_api/endpoints/users/export'
 require 'braze_api/endpoints/users/delete'
 require 'braze_api/endpoints/subscription_groups/status'
+require 'braze_api/endpoints/subscription_groups/status_get'
+require 'braze_api/endpoints/subscription_groups/statuses'
 
 module BrazeAPI
   # The top-level class that handles configuration and connection to the Braze API.
@@ -21,6 +23,8 @@ module BrazeAPI
     include BrazeAPI::Endpoints::Users::Export
     include BrazeAPI::Endpoints::Users::Delete
     include BrazeAPI::Endpoints::SubscriptionGroups::Status
+    include BrazeAPI::Endpoints::SubscriptionGroups::StatusGet
+    include BrazeAPI::Endpoints::SubscriptionGroups::Statuses
 
     def initialize(api_key:, braze_url:, app_id:)
       @api_key = api_key
@@ -31,6 +35,12 @@ module BrazeAPI
     # Returns a parsed response from a post request
     def post(endpoint, params: {})
       response = client.post(endpoint, params.to_json)
+      JSON.parse(response.body)
+    end
+
+    # Returns a parsed response from a get request
+    def get(endpoint, params: {})
+      response = client.get(endpoint, params)
       JSON.parse(response.body)
     end
 

--- a/lib/braze_api/endpoints/subscription_groups/status_get.rb
+++ b/lib/braze_api/endpoints/subscription_groups/status_get.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BrazeAPI
+  module Endpoints
+    module SubscriptionGroups
+      # Methods to call the subscription/status endpoint from a client instance
+      module StatusGet
+        PATH = '/subscription/status/get'
+        # The method to get a user subscription status
+        # Args object will look like:
+        # {subscription_group_id: id, external_id: uuid}
+        # with either an external_id or an email or a phone
+        # and subscription group id
+        def status(args = {})
+          args.compact!
+          get(PATH, params: args)
+        end
+      end
+    end
+  end
+end

--- a/lib/braze_api/endpoints/subscription_groups/statuses.rb
+++ b/lib/braze_api/endpoints/subscription_groups/statuses.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BrazeAPI
+  module Endpoints
+    module SubscriptionGroups
+      # Methods to call the subscription/status endpoint from a client instance
+      module Statuses
+        PATH = '/subscription/user/status'
+        # The method to get a users subscriptions status
+        # Args object will look like:
+        # {subscription_state: 'subscribed', subscription_group_id: id, external_id: uuid}
+        # with either an external_id or an email and the subscription state
+        # and subscription group id
+        def statuses(args = {})
+          args.compact!
+          get(PATH, params: args)
+        end
+      end
+    end
+  end
+end

--- a/spec/braze_api/endpoints/subscription_groups/status_get_spec.rb
+++ b/spec/braze_api/endpoints/subscription_groups/status_get_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe BrazeAPI::Endpoints::SubscriptionGroups::StatusGet do
+  let(:api_key) { 'abcdefg' }
+  let(:app_id) { 'hijklmnop' }
+  let(:braze_url) { 'https://rest.fra-01.braze.eu' }
+  let(:email) { 'hello@appearhere.co.uk' }
+  let(:phone) { '+440000000000' }
+  let(:external_id) { '12314es5' }
+  let(:subscription_group_id) { '12' }
+  let(:subject) { BrazeAPI::Client.new(api_key: api_key, app_id: app_id, braze_url: braze_url) }
+  before { allow(subject).to receive(:get).and_return('success') }
+
+  describe '.status' do
+    it 'gets the subscription status with an external id and subscription_group_id' do
+      expect(subject)
+        .to receive(:get)
+        .with(
+          '/subscription/status/get',
+          params: {
+            external_id: external_id,
+            subscription_group_id: subscription_group_id,
+          }
+        )
+
+      subject.status(
+        external_id: external_id,
+        subscription_group_id: subscription_group_id,
+      )
+    end
+
+    it 'gets the subscription status with an email and subscription_group_id' do
+      expect(subject)
+        .to receive(:get)
+        .with(
+          '/subscription/status/get',
+          params: {
+            email: email,
+            subscription_group_id: subscription_group_id,
+          }
+        )
+
+      subject.status(
+        email: email,
+        subscription_group_id: subscription_group_id,
+      )
+    end
+
+    it 'gets the subscription status with a phone and subscription_group_id' do
+      expect(subject)
+        .to receive(:get)
+        .with(
+          '/subscription/status/get',
+          params: {
+            phone: phone,
+            subscription_group_id: subscription_group_id,
+          }
+        )
+
+      subject.status(
+        phone: phone,
+        subscription_group_id: subscription_group_id,
+      )
+    end
+  end
+end

--- a/spec/braze_api/endpoints/subscription_groups/statuses_spec.rb
+++ b/spec/braze_api/endpoints/subscription_groups/statuses_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe BrazeAPI::Endpoints::SubscriptionGroups::Statuses do
+  let(:api_key) { 'abcdefg' }
+  let(:app_id) { 'hijklmnop' }
+  let(:braze_url) { 'https://rest.fra-01.braze.eu' }
+  let(:email) { 'hello@appearhere.co.uk' }
+  let(:phone) { '+440000000000' }
+  let(:external_id) { '12314es5' }
+  let(:subscription_group_id) { '12' }
+  let(:subject) { BrazeAPI::Client.new(api_key: api_key, app_id: app_id, braze_url: braze_url) }
+  before { allow(subject).to receive(:get).and_return('success') }
+
+  describe '.statuses' do
+    it 'gets the subscriptions statuses with an external id' do
+      expect(subject)
+        .to receive(:get)
+        .with(
+          '/subscription/user/status',
+          params: {
+            external_id: external_id
+          }
+        )
+
+      subject.statuses(
+        external_id: external_id
+      )
+    end
+
+    it 'gets the subscriptions statuses with an email' do
+      expect(subject)
+        .to receive(:get)
+        .with(
+          '/subscription/user/status',
+          params: {
+            email: email
+          }
+        )
+
+      subject.statuses(
+        email: email
+      )
+    end
+
+    it 'gets the subscriptions statuses with a phone' do
+      expect(subject)
+        .to receive(:get)
+        .with(
+          '/subscription/user/status',
+          params: {
+            phone: phone
+          }
+        )
+
+      subject.statuses(
+        phone: phone
+      )
+    end
+  end
+end


### PR DESCRIPTION
* Allows to retrieve a list of subscriptions groups for a given user (via phone, email or external_id)
* Allows to retrieve the status of an specific subscription group for a given user (via phone, email or external_id)