### PR TITLE
CHORE fix version history and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
+# v0.1.4
+
+- **BREAKING** Previous `BrazeAPI::Endpoints::SubscriptionGroups::Status` module has been renamed to `BrazeAPI::Endpoints::SubscriptionGroups::Status::Update`
+- Adds support to list all subscription groups for a user via `BrazeAPI::Endpoints::SubscriptionGroups::Status::List#statuses`
+- Adds support to get subscription group status for a user via `BrazeAPI::Endpoints::SubscriptionGroups::Status::Get#status`
+
 # v0.1.3
 
-Previous `BrazeAPI::Endpoints::SubscriptionGroups::Status` module has been renamed to `BrazeAPI::Endpoints::SubscriptionGroups::Status::Update`
-Adds support to list all subscription groups for a user via `BrazeAPI::Endpoints::SubscriptionGroups::Status::List#statuses`
-Adds support to get subscription group status for a user via `BrazeAPI::Endpoints::SubscriptionGroups::Status::Get#status`
+- **BREAKING** Updates ruby version to 2.7, rubocop to 1.0, and dependencies.
+- Fixes security vulnerabilities.
 
 # v0.1.2
 
-Adds method to delete users.
+- Adds method to delete users.
 
-Updates ruby version to 2.7, rubocop to 1.0, and dependencies.
-Fixes security vulnerabilities.
+# v0.1.1
 
-Breaking changes - will only support ruby version 2.7 and higher
+- Update faraday dependency to v0.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    braze_api (0.1.3)
+    braze_api (0.1.4)
       faraday (~> 0.15)
 
 GEM
@@ -63,4 +63,4 @@ DEPENDENCIES
   rubocop (~> 1.0)
 
 BUNDLED WITH
-   2.0.1
+   2.3.8

--- a/lib/braze_api/version.rb
+++ b/lib/braze_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrazeAPI
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
Bump version to accurately reflect version history.
Tidy up the changelog, ensuring version changes are recorded correctly.